### PR TITLE
exception handling

### DIFF
--- a/Faultify.Analyze/RandomValueGenerator.cs
+++ b/Faultify.Analyze/RandomValueGenerator.cs
@@ -112,9 +112,9 @@ namespace Faultify.Analyze
         /// <returns>The random numeric object</returns>
         private static object ChangeNumber(Type type, object original)
         {
-            if (!TypeChecker.IsNumericType(type))
+            if (!TypeChecker.IsNumericType(type)) //Is this really necessary? Since this method is only called when it is a numeric type
             {
-                throw new ArgumentException("The given type is not numeric", nameof(type));
+                throw new ArgumentException("The given type is not numeric", nameof(type)); 
             }
             
             while (true)

--- a/Faultify.Cli/Program.cs
+++ b/Faultify.Cli/Program.cs
@@ -236,13 +236,23 @@ namespace Faultify.Cli
 
         private IReporter ReportFactory(string type)
         {
-            return type?.ToUpper() switch
+            try
             {
-                "PDF" => new PdfReporter(),
-                "HTML" => new HtmlReporter(),
-                "JSON" => new JsonReporter(),
-                _ => throw new ArgumentException($"The argument \"{type}\" is not a valid file output type"),
-            };
+                return type?.ToUpper() switch
+                {
+                    "PDF" => new PdfReporter(),
+                    "HTML" => new HtmlReporter(),
+                    "JSON" => new JsonReporter(),
+                    _ => throw new ArgumentOutOfRangeException(type, $"The argument \"{type}\" is not a valid file output type." +
+                        "Defaulting to JSON."),
+                };
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                _logger.Error(ex, ex.Message);
+                return new JsonReporter();
+            }
+            
         }
 
         private static IConfigurationRoot BuildConfigurationRoot()

--- a/Faultify.Injection/TestCoverageInjector.cs
+++ b/Faultify.Injection/TestCoverageInjector.cs
@@ -6,6 +6,7 @@ using Faultify.TestRunner.Shared;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MethodAttributes = Mono.Cecil.MethodAttributes;
+using NLog;
 
 namespace Faultify.Injection
 {
@@ -20,6 +21,7 @@ namespace Faultify.Injection
         private readonly MethodDefinition _initializeMethodDefinition;
         private readonly MethodDefinition _registerTargetCoverage;
         private readonly MethodDefinition _registerTestCoverage;
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
         private TestCoverageInjector()
         {
@@ -44,7 +46,8 @@ namespace Faultify.Injection
 
             if (_initializeMethodDefinition == null || _registerTargetCoverage == null)
             {
-                throw new Exception("Testcoverage Injector could not initialize injection methods");
+                _logger.Fatal("Testcoverage Injector could not initialize injection methods");
+                Environment.Exit(13);
             }
         }
 

--- a/Faultify.TestRunner.Collector/TestDataCollector.cs
+++ b/Faultify.TestRunner.Collector/TestDataCollector.cs
@@ -50,9 +50,9 @@ namespace Faultify.TestRunner.Collector
                 byte[] serialized = _testResults.Serialize();
                 File.WriteAllBytes(TestRunnerConstants.TestsFileName, serialized);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                _logger.LogError(context.SessionDataCollectionContext, "Test Session Exception: {ex}");
+                _logger.LogError(context.SessionDataCollectionContext, $"Test Session Exception: {ex}");
             }
 
             _logger.LogWarning(context.SessionDataCollectionContext, "Test Session Finished");

--- a/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
+++ b/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
@@ -76,7 +76,7 @@ namespace Faultify.TestRunner.Dotnet
                 }
                 catch (FileNotFoundException)
                 {
-                    _logger.Error(
+                    _logger.Fatal(
                         "The file 'test_results.bin' was not generated."
                         + "This implies that the test run can not be completed. "
                     );

--- a/Faultify.TestRunner.XUnit/XUnitTestHostRunner.cs
+++ b/Faultify.TestRunner.XUnit/XUnitTestHostRunner.cs
@@ -7,12 +7,14 @@ using Faultify.MemoryTest.TestInformation;
 using Faultify.TestRunner.Shared;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using TestResult = Faultify.TestRunner.Shared.TestResult;
+using NLog;
 
 namespace Faultify.TestRunner.XUnit
 {
     [Obsolete("Moved into TestRunner.TestRun.TestHostRunners")]
     public class XUnitTestHostRunner : ITestHostRunner
     {
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
         private readonly HashSet<string> _coverageTests = new HashSet<string>();
         private readonly string _testProjectAssemblyPath;
         private readonly TestResults _testResults = new TestResults();
@@ -60,13 +62,21 @@ namespace Faultify.TestRunner.XUnit
 
         private TestOutcome ParseTestOutcome(MemoryTest.TestOutcome outcome)
         {
-            return outcome switch
+            try
             {
-                MemoryTest.TestOutcome.Passed => TestOutcome.Passed,
-                MemoryTest.TestOutcome.Failed => TestOutcome.Failed,
-                MemoryTest.TestOutcome.Skipped => TestOutcome.Skipped,
-                _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
-            };
+                return outcome switch
+                {
+                    MemoryTest.TestOutcome.Passed => TestOutcome.Passed,
+                    MemoryTest.TestOutcome.Failed => TestOutcome.Failed,
+                    MemoryTest.TestOutcome.Skipped => TestOutcome.Skipped,
+                    _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
+                };
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                _logger.Error(ex, ex.Message + "defautling to Skipped");
+                return TestOutcome.Skipped;
+            }
         }
 
         private MutationCoverage ReadCoverageFile()

--- a/Faultify.TestRunner/MutationTestProject.cs
+++ b/Faultify.TestRunner/MutationTestProject.cs
@@ -114,9 +114,14 @@ namespace Faultify.TestRunner
 
             Stopwatch? coverageTimer = new Stopwatch();
             coverageTimer.Start();
-            MutationCoverage coverage =
+            MutationCoverage? coverage =
                 await RunCoverage(coverageProject.TestProjectFile.FullFilePath(), cancellationToken);
             coverageTimer.Stop();
+            if (coverage == null)
+            {
+                _logger.Fatal("Coverage failed exiting with exit code 16");
+                Environment.Exit(16);
+            }
 
             TimeSpan timeout = CreateTimeOut(coverageTimer);
 
@@ -252,7 +257,7 @@ namespace Faultify.TestRunner
         /// <param name="testAssemblyPath"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        private async Task<MutationCoverage> RunCoverage(string testAssemblyPath, CancellationToken cancellationToken)
+        private async Task<MutationCoverage?> RunCoverage(string testAssemblyPath, CancellationToken cancellationToken)
         {
             _logger.Info("Running coverage analysis");
             using MemoryMappedFile? file = Utils.CreateCoverageMemoryMappedFile();
@@ -264,8 +269,8 @@ namespace Faultify.TestRunner
             }
             catch (Exception e)
             {
-                _logger.Error(e, "Unable to create Test Runner");
-                throw; // TODO: Maybe return null
+                _logger.Error(e, "Unable to create Test Runner returning null");
+                return null;
             }
 
             return await testRunner.RunCodeCoverage(cancellationToken);

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicator.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Faultify.Core.ProjectAnalyzing;
+using NLog;
 
 namespace Faultify.TestRunner.ProjectDuplication
 {
@@ -16,6 +17,8 @@ namespace Faultify.TestRunner.ProjectDuplication
         private List<string>? _allFiles;
 
         private IProjectInfo? _projectInfo;
+
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
         public TestProjectDuplicator(string testDirectory)
         {
@@ -71,7 +74,8 @@ namespace Faultify.TestRunner.ProjectDuplication
                 }
                 catch (Exception e)
                 {
-                    throw e;
+                    _logger.Fatal(e, $"failed to copy test project {e}");
+                    Environment.Exit(14);
                 }
             }
 
@@ -101,7 +105,11 @@ namespace Faultify.TestRunner.ProjectDuplication
         /// <returns> The newly created duplication </returns>
         public TestProjectDuplication MakeCopy(int i)
         {
-            if (_newDirInfo == null || _projectInfo == null) throw new NullReferenceException();
+            if (_newDirInfo == null || _projectInfo == null)
+            {
+                _logger.Fatal("null reference for new directory or project info");
+                Environment.Exit(15);
+            }
             
             string duplicatedDirectoryPath = Path.Combine(_testDirectory, $"test-duplication-{i + 1}");
             

--- a/Faultify.TestRunner/TestRun/TestHostRunnerFactory.cs
+++ b/Faultify.TestRunner/TestRun/TestHostRunnerFactory.cs
@@ -21,16 +21,24 @@ namespace Faultify.TestRunner.TestRun
         /// <returns></returns>
         public static ITestHostRunner CreateTestRunner(string testAssemblyPath, TimeSpan timeOut, TestHost testHost)
         {
+            ITestHostRunner testRunner;
             _logger.Info("Creating test runner");
-            ITestHostRunner testRunner = testHost switch
+            try
             {
-                TestHost.NUnit => new NUnitTestHostRunner(testAssemblyPath, timeOut),
-                TestHost.XUnit => new XUnitTestHostRunner(testAssemblyPath),
-                TestHost.MsTest => new DotnetTestHostRunner(testAssemblyPath, timeOut),
-                TestHost.DotnetTest => new DotnetTestHostRunner(testAssemblyPath, timeOut),
-                _ => throw new Exception("Test host not found"), //TODO: Probably bad practice
-            };
-
+                testRunner = testHost switch
+                {
+                    TestHost.NUnit => new NUnitTestHostRunner(testAssemblyPath, timeOut),
+                    TestHost.XUnit => new XUnitTestHostRunner(testAssemblyPath),
+                    TestHost.MsTest => new DotnetTestHostRunner(testAssemblyPath, timeOut),
+                    TestHost.DotnetTest => new DotnetTestHostRunner(testAssemblyPath, timeOut),
+                    _ => throw new ArgumentOutOfRangeException(nameof(testHost), $"{testHost} not found."),
+                };
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, ex.Message + "Defaulting to DotNetTest.");
+                testRunner = new DotnetTestHostRunner(testAssemblyPath, timeOut);
+            }
             return testRunner;
         }
     }

--- a/Faultify.TestRunner/TestRun/TestHostRunners/NUnitTestHostRunner.cs
+++ b/Faultify.TestRunner/TestRun/TestHostRunners/NUnitTestHostRunner.cs
@@ -75,13 +75,20 @@ namespace Faultify.TestRunner.TestRun.TestHostRunners
 
         private TestOutcome ParseTestOutcome(MemoryTest.TestOutcome outcome)
         {
-            return outcome switch
+            try
             {
-                MemoryTest.TestOutcome.Passed => TestOutcome.Passed,
-                MemoryTest.TestOutcome.Failed => TestOutcome.Failed,
-                MemoryTest.TestOutcome.Skipped => TestOutcome.Skipped,
-                _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
-            };
+                return outcome switch
+                {
+                    MemoryTest.TestOutcome.Passed => TestOutcome.Passed,
+                    MemoryTest.TestOutcome.Failed => TestOutcome.Failed,
+                    MemoryTest.TestOutcome.Skipped => TestOutcome.Skipped,
+                    _ => throw new ArgumentOutOfRangeException(nameof(outcome), outcome, null),
+                };
+            } catch(ArgumentOutOfRangeException ex)
+            {
+                _logger.Error(ex, ex.Message + "defautling to Skipped");
+                return TestOutcome.Skipped;
+            }
         }
 
         private MutationCoverage ReadCoverageFile()


### PR DESCRIPTION
Almost all exceptions are handled except two. Of these two that aren't handled I believe one exception can just be removed and the other I don't know how to change.

            try
            {
                testRunner = TestHostRunnerFactory
                    .CreateTestRunner(testAssemblyPath, TimeSpan.FromSeconds(12), _testHost);
            }
            catch (Exception e)
            {
                _logger.Error(e, "Unable to create Test Runner");
                throw; // TODO: Maybe return null
            }
MutationTestProject.cs lines 260-269