### PR TITLE
Fix most unit tests and some minor bugs

### DIFF
--- a/Faultify.Analyze/Analyzers/IAnalyzer.cs
+++ b/Faultify.Analyze/Analyzers/IAnalyzer.cs
@@ -10,7 +10,7 @@ namespace Faultify.Analyze
     /// </summary>
     /// <typeparam name="TMutation">The type of the returned metadata.</typeparam>
     /// <typeparam name="TScope"></typeparam>
-    public interface IAnalyzer<TMutation, in TScope> where TMutation : IMutation
+    public interface IAnalyzer<TMutation, in TScope> where TMutation : IMutation 
     {
         /// <summary>
         ///     Name of the mutator.

--- a/Faultify.Analyze/Analyzers/VariableAnalyzer.cs
+++ b/Faultify.Analyze/Analyzers/VariableAnalyzer.cs
@@ -49,8 +49,8 @@ namespace Faultify.Analyze.Analyzers
                 try
                 {
 
-                    // Get variable type. Might throw InvalidCastException
-                    Type type = ((TypeReference) instruction.Operand).ToSystemType();
+                    // Get variable type
+                    Type type = ((VariableReference) instruction.Operand).Resolve().ToSystemType();
 
                     // Get previous instruction.
                     Instruction variableInstruction = instruction.Previous;
@@ -66,6 +66,7 @@ namespace Faultify.Analyze.Analyzers
                 }
                 catch (InvalidCastException e)
                 {
+                    // Might not be necessary anymore as casting is more robust.
                     Logger.Debug(e, $"Failed to get the type of {instruction.Operand}");
                 }
             }

--- a/Faultify.Analyze/ArrayMutationStrategy/ArrayBuilder.cs
+++ b/Faultify.Analyze/ArrayMutationStrategy/ArrayBuilder.cs
@@ -39,7 +39,7 @@ namespace Faultify.Analyze.ArrayMutationStrategy
 
                 list.Add(processor.Create(OpCodes.Dup));
 
-                if (length > 2147483647 && length < -2147483647)
+                if (length > int.MaxValue && length < int.MinValue)
                 {
                     list.Add(processor.Create(OpCodes.Ldc_I8, i));
                 }

--- a/Faultify.Analyze/Mutation/ConstantMutation.cs
+++ b/Faultify.Analyze/Mutation/ConstantMutation.cs
@@ -48,7 +48,7 @@ namespace Faultify.Analyze.Mutation
 
         public bool HasConstant(object constant)
         {
-            return ConstantField.Constant == constant;
+            return ConstantField.Constant.Equals(constant);
         }
 
         public string Report => $"{ConstantField} was changed from {Original} to {Replacement}.";

--- a/Faultify.Analyze/TypeChecker.cs
+++ b/Faultify.Analyze/TypeChecker.cs
@@ -33,6 +33,7 @@ namespace Faultify.Analyze
             ISet<Type> arrayTypes = new HashSet<Type>();
             arrayTypes.UnionWith(NumericTypes);
             arrayTypes.Add(typeof(bool));
+            arrayTypes.Add(typeof(char));
 
             return arrayTypes.Contains(t);
         }

--- a/Faultify.Core/Extensions/InstructionExtensions.cs
+++ b/Faultify.Core/Extensions/InstructionExtensions.cs
@@ -48,6 +48,11 @@ namespace Faultify.Core.Extensions
             return Type.GetType(typeRef.FullName);
         }
 
+        public static Type ToSystemType(this VariableReference varRef)
+        {
+            return Type.GetType(varRef.VariableType.FullName);
+        }
+
         public static OpCode GetLdcOpCodeByTypeReference(this TypeReference reference)
         {
             switch (Type.GetTypeCode(reference.ToSystemType()))

--- a/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicationPool.cs
+++ b/Faultify.TestRunner/ProjectDuplication/TestProjectDuplicationPool.cs
@@ -69,7 +69,7 @@ namespace Faultify.TestRunner.ProjectDuplication
         /// <returns></returns>
         public TestProjectDuplication? GetFreeProject()
         {
-            TestProjectDuplication? project = _testProjectDuplications.First(x => !x.IsInUse);
+            TestProjectDuplication? project = _testProjectDuplications.FirstOrDefault(x => !x.IsInUse);
             if (project != null)
             {
                 project.IsInUse = true;

--- a/Faultify.Tests/UnitTests/ConstantTests.cs
+++ b/Faultify.Tests/UnitTests/ConstantTests.cs
@@ -54,7 +54,7 @@ namespace Faultify.Tests.UnitTests
 
             // Act
             byte[] mutatedBinary =
-                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolTrueName, 0);
+                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolTrueName, 0 /* False */);
 
             using (DllTestHelper binaryInteractor = new DllTestHelper(mutatedBinary))
             {
@@ -74,7 +74,7 @@ namespace Faultify.Tests.UnitTests
 
             // Act
             byte[] mutatedBinary =
-                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolFalseName, 1);
+                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolFalseName, 1 /* True */);
 
             using (DllTestHelper binaryInteractor = new DllTestHelper(mutatedBinary))
             {

--- a/Faultify.Tests/UnitTests/ConstantTests.cs
+++ b/Faultify.Tests/UnitTests/ConstantTests.cs
@@ -54,11 +54,11 @@ namespace Faultify.Tests.UnitTests
 
             // Act
             byte[] mutatedBinary =
-                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolTrueName, false);
+                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolTrueName, 0);
 
             using (DllTestHelper binaryInteractor = new DllTestHelper(mutatedBinary))
             {
-                object actual = binaryInteractor.GetField(nameSpace, ConstantBoolTrueName);
+                object actual = binaryInteractor.GetField(nameSpace, ConstantBoolFalseName);
 
                 // Assert
                 Assert.AreEqual(expected, actual);
@@ -74,7 +74,7 @@ namespace Faultify.Tests.UnitTests
 
             // Act
             byte[] mutatedBinary =
-                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolFalseName, true);
+                DllTestHelper.MutateField<ConstantAnalyzer>(binary, ConstantBoolFalseName, 1);
 
             using (DllTestHelper binaryInteractor = new DllTestHelper(mutatedBinary))
             {

--- a/Faultify.Tests/UnitTests/DecompilerTests.cs
+++ b/Faultify.Tests/UnitTests/DecompilerTests.cs
@@ -1,10 +1,11 @@
-﻿using System;
+﻿extern alias MC;
+using System;
 using System.IO;
 using System.Reflection.Metadata;
 using Faultify.Core.ProjectAnalyzing;
 using Faultify.Tests.UnitTests.Utils;
 using NUnit.Framework;
-using ModuleDefinition = Mono.Cecil.ModuleDefinition;
+using ModuleDefinition = MC::Mono.Cecil.ModuleDefinition;
 
 namespace Faultify.Tests.UnitTests
 {

--- a/Faultify.Tests/UnitTests/Utils/DecompileHandleHelper.cs
+++ b/Faultify.Tests/UnitTests/Utils/DecompileHandleHelper.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿extern alias MC;
+using System;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
-using FieldDefinition = Mono.Cecil.FieldDefinition;
-using MethodDefinition = Mono.Cecil.MethodDefinition;
-using ModuleDefinition = Mono.Cecil.ModuleDefinition;
-using TypeDefinition = Mono.Cecil.TypeDefinition;
+using FieldDefinition = MC::Mono.Cecil.FieldDefinition;
+using MethodDefinition = MC::Mono.Cecil.MethodDefinition;
+using ModuleDefinition = MC::Mono.Cecil.ModuleDefinition;
+using TypeDefinition = MC::Mono.Cecil.TypeDefinition;
 
 namespace Faultify.Tests.UnitTests.Utils
 {


### PR DESCRIPTION
Joran and I have fixed the majority of existing Unit Tests within Faultify. During the fix I managed to fix a Type casting issue (see `VariableAnalyzer.cs`) and now Faultify can run a lot more mutations (Benchmarks went from ~140 to ~210 mutations).

There are also some minor corrections to parts of code.

Further work needs to be done to get the last unit tests working. Plus, new unit tests should be created in the next few sprints.