### PR TITLE
Cleanup and documentation of Faultify.Cli

### DIFF
--- a/Faultify.Cli/Program.cs
+++ b/Faultify.Cli/Program.cs
@@ -24,12 +24,19 @@ using LogLevel = Microsoft.Extensions.Logging.LogLevel;
 
 namespace Faultify.Cli
 {
+    /// <summary>
+    /// The main instance of Faultify
+    /// </summary>
     internal class Program
     {
         private static string? _outputDirectory;
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-
+        /// <summary>
+        /// Program entrypoint
+        /// </summary>
+        /// <param name="args">Commandline arguments</param>
+        /// <exception cref="Exception">Faultify service cannot be accessed</exception>
         private static async Task Main(string[] args)
         {
             Settings settings = ParseCommandlineArguments(args);
@@ -103,6 +110,11 @@ namespace Faultify.Cli
             LogManager.Configuration = config;
         }
 
+        /// <summary>
+        /// Validates and parses commandline arguments into a Settings object
+        /// </summary>
+        /// <param name="args">Command line arguments</param>
+        /// <returns>A Settings object derived from the arguments</returns>
         private static Settings ParseCommandlineArguments(string[] args)
         {
             Settings settings = new Settings();
@@ -114,7 +126,11 @@ namespace Faultify.Cli
 
             return settings;
         }
-
+        
+        /// <summary>
+        /// Prints the program progress to the console
+        /// </summary>
+        /// <param name="progress"></param>
         private void PrintProgress(MutationRunProgress progress)
         {
             if (progress.LogMessageType == LogMessageType.TestRunUpdate
@@ -132,7 +148,11 @@ namespace Faultify.Cli
             }
         }
 
-        private async Task Run(Settings settings)
+        /// <summary>
+        /// Executes the core program flow for faultify
+        /// </summary>
+        /// <param name="settings">A settings object containing the parameters for this program run</param>
+        private async Task Run()
         {
             ConsoleMessage.PrintLogo();
             ConsoleMessage.PrintSettings(settings);
@@ -160,6 +180,12 @@ namespace Faultify.Cli
             await Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Runs coverage, analysis, mutations and tests
+        /// </summary>
+        /// <param name="settings">Program settings</param>
+        /// <param name="progressTracker">Progress tracker</param>
+        /// <returns>A report model with the results of the tests</returns>
         private async Task<TestProjectReportModel> RunMutationTest(
             Settings settings,
             MutationSessionProgressTracker progressTracker
@@ -178,7 +204,11 @@ namespace Faultify.Cli
             return await mutationTestProject.Test(progressTracker, CancellationToken.None);
         }
 
-        private async Task GenerateReport(TestProjectReportModel testResult, Settings settings)
+        /// <summary>
+        /// Builds a report based on the test results and program settings
+        /// </summary>
+        /// <param name="testResult">Report model with the test results</param>
+        private async Task GenerateReport(TestProjectReportModel testResult)
         {
             if (string.IsNullOrEmpty(settings.ReportPath))
             {
@@ -195,7 +225,13 @@ namespace Faultify.Cli
 
             await File.WriteAllBytesAsync(Path.Combine(_outputDirectory ?? string.Empty, reportFileName), reportBytes);
         }
-
+        
+        /// <summary>
+        /// Selects the appropriate Report Builder
+        /// </summary>
+        /// <param name="type">Report type, must be one of "PDF", "HTML", or "JSON"</param>
+        /// <returns>The reporter instance</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Wrong report type</exception>
         private IReporter ReportFactory(string type)
         {
             try
@@ -216,7 +252,11 @@ namespace Faultify.Cli
             }
             
         }
-
+        
+        /// <summary>
+        /// Helper method to generate a ConfigurationRoot
+        /// </summary>
+        /// <returns>The IConfigurationRoot object</returns>
         private static IConfigurationRoot BuildConfigurationRoot()
         {
             ConfigurationBuilder builder = new ConfigurationBuilder();

--- a/Faultify.Cli/Settings.cs
+++ b/Faultify.Cli/Settings.cs
@@ -124,7 +124,7 @@ namespace Faultify.Cli
         public TimeSpan TimeOut => TimeSpan.FromSeconds(_seconds);
 
         /// <summary>
-        /// The name of the test host framework. options:  "NUnit", "XUnit", "MsTest", "DotnetTest".
+        /// The name of the test host framework. options:  "NUnit", "MsTest", "DotnetTest".
         /// </summary>
         public TestHost TestHost
         {

--- a/Faultify.Cli/Settings.cs
+++ b/Faultify.Cli/Settings.cs
@@ -16,7 +16,7 @@ namespace Faultify.Cli
     
     internal class Settings
     {
-        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
+        private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
         /// <summary>
         /// The path pointing to the test project project file.
@@ -28,7 +28,8 @@ namespace Faultify.Cli
         /// <summary>
         /// The root directory were the reports will be saved.
         /// </summary>
-        [Option('r', "reportPath", Required = false, HelpText = "The path were the report will be saved.")]
+        [Option('r', "reportPath", Required = false,
+            HelpText = "The path were the report will be saved.")]
         public string ReportPath { get; set; } = Path.Combine(Directory.GetCurrentDirectory(), "FaultifyOutput");
 
         /// <summary>
@@ -57,30 +58,34 @@ namespace Faultify.Cli
         /// </summary>
         [Option('t', "testHost", Required = false, Default = nameof(TestHost.DotnetTest),
             HelpText = "The name of the test host framework.")]
-        public string TestHostName { get; set; }
+        public string _testHostName { get; set; }
 
         /// <summary>
         /// Time out in seconds for each mutation.
         /// </summary>
-        [Option('d', "timeOut", Required = false, Default = 0, HelpText = "Time out in seconds for the mutations")]
-        public double Seconds { get; set; }
+        [Option('d', "timeOut", Required = false, Default = 0,
+            HelpText = "Time out in seconds for the mutations")]
+        public double _seconds { get; set; }
 
         /// <summary>
         /// Mutation groups to be excluded
         /// </summary>
-        [Option('g', "excludeMutationGroups", Required = false, Default = null, HelpText = "Mutation groups to be excluded")]
+        [Option('g', "excludeMutationGroups", Required = false, Default = null,
+            HelpText = "Mutation groups to be excluded")]
         public IEnumerable<string> ExcludeMutationGroups { get; set;}
 
         /// <summary>
         /// Individual mutation ids to be excluded
         /// </summary>
-        [Option('s', "excludeMutationSingles", Required = false, Default = null, HelpText = "Individual mutation ids to be excluded")]
+        [Option('s', "excludeMutationSingles", Required = false, Default = null,
+            HelpText = "Individual mutation ids to be excluded")]
         public IEnumerable<string> _excludeMutationSingles { get; set; }
 
         /// <summary>
         /// Path to a json file detailing individual mutations to be excluded
         /// </summary>
-        [Option('e', "excludeMutationSinglesFile", Required = false, Default = "NoFile", HelpText = "Path to a json file detailing individual mutations to be excluded")]
+        [Option('e', "excludeMutationSinglesFile", Required = false, Default = "NoFile",
+            HelpText = "Path to a json file detailing individual mutations to be excluded")]
         public string _excludeMutationSinglesFile { get; set; }
 
         /// <summary>
@@ -90,37 +95,29 @@ namespace Faultify.Cli
         { 
             get
             {
-                if (ExcludeMutationSinglesFile.Equals("NoFile"))
+                if (_excludeMutationSinglesFile.Equals("NoFile"))
                 {
-                    return ExcludeMutationSingles.ToHashSet<string>();
+                    return _excludeMutationSingles.ToHashSet<string>();
                 }
-                else
+
+                string[]? excludeMutations;
+                try
                 {
-                    string jsonString;
-                    string[]? excludeMutations;
-                    try
-                    {
-                        jsonString = File.ReadAllText(ExcludeMutationSinglesFile);
-                        excludeMutations = JsonSerializer.Deserialize<string[]>(jsonString);
-                    } catch(Exception ex)
-                    {
-                        _logger.Error(ex, "Defaulting to -s exclusions" + ex.Message);
-                        excludeMutations = null;
-                    }
-                    
-                    
-                    if (excludeMutations == null)
-                    {
-                        return ExcludeMutationSingles.ToHashSet<string>();
-                    }
-                    else
-                    {
-                        return new HashSet<string>(excludeMutations);
-                    }
-                    
+                    string jsonString = File.ReadAllText(_excludeMutationSinglesFile);
+                    excludeMutations = JsonSerializer.Deserialize<string[]>(jsonString);
                 }
+                catch(Exception ex)
+                {
+                    Logger.Warn(ex, "Defaulting to -s exclusions" + ex.Message);
+                    excludeMutations = null;
+                }
+                
+                return excludeMutations == null
+                    ? _excludeMutationSingles.ToHashSet()
+                    : new HashSet<string>(excludeMutations);
             }
         }
+        
         /// <summary>
         /// Time out in seconds for each mutation.
         /// </summary>
@@ -131,8 +128,13 @@ namespace Faultify.Cli
         /// </summary>
         public TestHost TestHost
         {
-            get => Enum.Parse<TestHost>(TestHostName, true);
-            set => TestHostName = value.ToString();
+            get => Enum.Parse<TestHost>(_testHostName, true);
+            set => _testHostName = value.ToString();
         }
+        
+        /// <summary>
+        /// The directory where the current report will be saved to
+        /// </summary>
+        public string OutputDirectory => Path.Combine(ReportPath, DateTime.Now.ToString("yy-MM-dd"));
     }
 }

--- a/Faultify.Cli/Settings.cs
+++ b/Faultify.Cli/Settings.cs
@@ -18,41 +18,74 @@ namespace Faultify.Cli
     {
         private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
 
+        /// <summary>
+        /// The path pointing to the test project project file.
+        /// </summary>
         [Option('i', "inputProject", Required = true,
             HelpText = "The path pointing to the test project project file.")]
         public string TestProjectPath { get; set; }
 
+        /// <summary>
+        /// The root directory were the reports will be saved.
+        /// </summary>
         [Option('r', "reportPath", Required = false, HelpText = "The path were the report will be saved.")]
         public string ReportPath { get; set; } = Path.Combine(Directory.GetCurrentDirectory(), "FaultifyOutput");
 
+        /// <summary>
+        /// Type of report to be generated, options: 'pdf', 'html', 'json'
+        /// </summary>
         [Option('f', "reportFormat", Required = false, Default = "json",
             HelpText = "Type of report to be generated, options: 'pdf', 'html', 'json'")]
         public string ReportType { get; set; }
 
+        /// <summary>
+        /// Defines how many test sessions are ran at the same time.
+        /// </summary>
         [Option('p', "parallel", Required = false, Default = 1,
             HelpText = "Defines how many test sessions are ran at the same time.")]
         public int Parallel { get; set; }
 
+        /// <summary>
+        /// The mutation level indicating the test depth.
+        /// </summary>
         [Option('l', "mutationLevel", Required = false, Default = MutationLevel.Detailed,
-            HelpText = "The mutation level indicating the test depth. ")]
+            HelpText = "The mutation level indicating the test depth.")]
         public MutationLevel MutationLevel { get; set; }
 
+        /// <summary>
+        /// The name of the test host framework. options:  "NUnit", "XUnit", "MsTest", "DotnetTest".
+        /// </summary>
         [Option('t', "testHost", Required = false, Default = nameof(TestHost.DotnetTest),
             HelpText = "The name of the test host framework.")]
         public string TestHostName { get; set; }
 
+        /// <summary>
+        /// Time out in seconds for each mutation.
+        /// </summary>
         [Option('d', "timeOut", Required = false, Default = 0, HelpText = "Time out in seconds for the mutations")]
         public double Seconds { get; set; }
 
-        [Option('g', "excludeMutationGroups", Required = false, Default = null, HelpText = "Exclude mutations based on groupings")]
+        /// <summary>
+        /// Mutation groups to be excluded
+        /// </summary>
+        [Option('g', "excludeMutationGroups", Required = false, Default = null, HelpText = "Mutation groups to be excluded")]
         public IEnumerable<string> ExcludeMutationGroups { get; set;}
 
-        [Option('s', "excludeMutationSingles", Required = false, Default = null, HelpText = "Exclude mutations based on their individual id")]
-        public IEnumerable<string> ExcludeMutationSingles { get; set; }
+        /// <summary>
+        /// Individual mutation ids to be excluded
+        /// </summary>
+        [Option('s', "excludeMutationSingles", Required = false, Default = null, HelpText = "Individual mutation ids to be excluded")]
+        public IEnumerable<string> _excludeMutationSingles { get; set; }
 
-        [Option('e', "excludeMutationSinglesFile", Required = false, Default = "NoFile", HelpText = "Exclude mutations based on individual id in a JSON file")]
-        public string ExcludeMutationSinglesFile { get; set; }
+        /// <summary>
+        /// Path to a json file detailing individual mutations to be excluded
+        /// </summary>
+        [Option('e', "excludeMutationSinglesFile", Required = false, Default = "NoFile", HelpText = "Path to a json file detailing individual mutations to be excluded")]
+        public string _excludeMutationSinglesFile { get; set; }
 
+        /// <summary>
+        /// Set of individual mutations that should be excluded
+        /// </summary>
         public HashSet<string> ExcludeSingleMutations 
         { 
             get
@@ -88,9 +121,14 @@ namespace Faultify.Cli
                 }
             }
         }
+        /// <summary>
+        /// Time out in seconds for each mutation.
+        /// </summary>
+        public TimeSpan TimeOut => TimeSpan.FromSeconds(_seconds);
 
-        public TimeSpan TimeOut => TimeSpan.FromSeconds(Seconds);
-
+        /// <summary>
+        /// The name of the test host framework. options:  "NUnit", "XUnit", "MsTest", "DotnetTest".
+        /// </summary>
         public TestHost TestHost
         {
             get => Enum.Parse<TestHost>(TestHostName, true);


### PR DESCRIPTION
- Made Settings a member of the Program class, it used to be passed around everywhere.
- Made output directory into a property of Settings.
- Reworked some code for simplicity and legibility.
- Reworked an exception that was thrown at the main-level into a log-and-quit.