### PR TITLE
Sprint 9 - Cln 08 unit testing

### DIFF
--- a/Faultify.Analyze/ArrayMutationStrategy/ArrayBuilder.cs
+++ b/Faultify.Analyze/ArrayMutationStrategy/ArrayBuilder.cs
@@ -23,7 +23,9 @@ namespace Faultify.Analyze.ArrayMutationStrategy
         {
             OpCode opcodeTypeValueAssignment = arrayType.GetLdcOpCodeByTypeReference();
             OpCode stelem = arrayType.GetStelemByTypeReference();
-            if (arrayType.ToSystemType() == typeof(long) || arrayType.ToSystemType() == typeof(ulong))
+            var arraySystemType = arrayType.ToSystemType();
+
+            if (arraySystemType == typeof(long) || arraySystemType == typeof(ulong))
             {
                 opcodeTypeValueAssignment = OpCodes.Ldc_I4;
             }
@@ -35,7 +37,7 @@ namespace Faultify.Analyze.ArrayMutationStrategy
             };
             for (var i = 0; i < length; i++)
             {
-                object random = RandomValueGenerator.GenerateValueForField(arrayType.ToSystemType(), 0);
+                object random = RandomValueGenerator.GenerateValueForField(arraySystemType, 0);
 
                 list.Add(processor.Create(OpCodes.Dup));
 
@@ -48,9 +50,17 @@ namespace Faultify.Analyze.ArrayMutationStrategy
                     list.Add(processor.Create(OpCodes.Ldc_I4, i));
                 }
 
-                list.Add(processor.Create(opcodeTypeValueAssignment, random));
+                if (arraySystemType == typeof(char))
+                {
+                    int charCode = (int) char.GetNumericValue((char) random);
+                    list.Add(processor.Create(opcodeTypeValueAssignment, charCode));
 
-                if (arrayType.ToSystemType() == typeof(long) || arrayType.ToSystemType() == typeof(ulong))
+                } else
+                {
+                    list.Add(processor.Create(opcodeTypeValueAssignment, random));
+                }
+
+                if (arraySystemType == typeof(long) || arraySystemType == typeof(ulong))
                 {
                     list.Add(processor.Create(OpCodes.Conv_I8));
                 }

--- a/Faultify.Analyze/ArrayMutationStrategy/DynamicArrayRandomizerStrategy.cs
+++ b/Faultify.Analyze/ArrayMutationStrategy/DynamicArrayRandomizerStrategy.cs
@@ -22,7 +22,7 @@ namespace Faultify.Analyze.ArrayMutationStrategy
         }
 
         /// <summary>
-        ///     Mutates a dynamic array by creating a new array with random values with the arraybuilder.
+        ///     Mutates a dynamic array by creating a new array with random values using the arraybuilder.
         /// </summary>
         public void Mutate()
         {
@@ -35,22 +35,22 @@ namespace Faultify.Analyze.ArrayMutationStrategy
 
             // Find array to replace
             foreach (Instruction instruction in _methodDefinition.Body.Instructions)
-                // add all instruction before dynamic array to list.
+                // Add all instruction before dynamic array to list.
             {
                 if (!instruction.IsDynamicArray())
                 {
                     beforeArray.Add(instruction);
                 }
-                // if dynamic array add all instructions after the array initialisation.
+                // If it's a dynamic array, add all instructions after the array initialisation.
                 else
                 {
                     beforeArray.Remove(instruction.Previous);
-                    // get type of array
+                    // Get type of array
                     _type = (TypeReference) instruction.Operand;
 
                     Instruction previous = instruction.Previous;
                     Instruction call = instruction.Next.Next.Next;
-                    // get length of array.
+                    // Get length of array.
                     length = (int) previous.Operand;
 
                     // Add all other nodes to the list.
@@ -67,15 +67,15 @@ namespace Faultify.Analyze.ArrayMutationStrategy
 
             processor.Clear();
 
-            // append everything before array.
+            // Append everything before array.
             foreach (Instruction before in beforeArray) processor.Append(before);
 
             List<Instruction> newArray = _arrayBuilder.CreateArray(processor, length, _type);
 
-            // append new array
+            // Append new array
             foreach (Instruction newInstruction in newArray) processor.Append(newInstruction);
 
-            // append after array.
+            // Append after array.
             foreach (Instruction after in afterArray) processor.Append(after);
             _methodDefinition.Body.OptimizeMacros();
         }

--- a/Faultify.Analyze/RandomValueGenerator.cs
+++ b/Faultify.Analyze/RandomValueGenerator.cs
@@ -127,11 +127,6 @@ namespace Faultify.Analyze
         /// <returns>The random numeric object</returns>
         private static object ChangeNumber(Type type, object original)
         {
-            if (!TypeChecker.IsNumericType(type)) //Is this really necessary? Since this method is only called when it is a numeric type
-            {
-                throw new ArgumentException("The given type is not numeric", nameof(type)); 
-            }
-            
             while (true)
             {
                 // Get a random value of a specified type, within the specified type's size range.
@@ -144,8 +139,9 @@ namespace Faultify.Analyze
                 } 
                 else
                 {
-                    //TODO: this can theoretically generate an extremely small negative value out of range
-                    //Also, this is a really hacky fix
+                    // This is a really hacky solution.
+                    // Get the maximum possible value of a type from a list
+                    // If it's too big, settle for int32 maximum value.
                     var maxSize = sizes.GetValueOrDefault(type) / 2;
                     var bound = maxSize >= int.MaxValue ? int.MaxValue : maxSize; 
                     generated = Convert.ToInt32(Rand.Next((int) bound));

--- a/Faultify.TestRunner/TestProcess/ProcessRunner.cs
+++ b/Faultify.TestRunner/TestProcess/ProcessRunner.cs
@@ -32,8 +32,8 @@ namespace Faultify.TestRunner.TestProcess
 
             process.StartInfo = _processStartInfo;
 
-            process.OutputDataReceived += (sender, e) => { Logger.Debug(e.Data); };
-            process.ErrorDataReceived += (sender, e) => { Logger.Error(e.Data); };
+            process.OutputDataReceived += (sender, e) => { if (e.Data != null) Logger.Debug(e.Data); };
+            process.ErrorDataReceived += (sender, e) => { if (e.Data != null) Logger.Error(e.Data); };
 
             process.Start();
 

--- a/Faultify.Tests/UnitTests/ArithmeticTests.cs
+++ b/Faultify.Tests/UnitTests/ArithmeticTests.cs
@@ -7,6 +7,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test mutations of arithmetic operations.
+    /// </summary>
     internal class ArithmeticTests
     {
         private readonly string _folder = Path.Combine("UnitTests", "TestSource", "ArithmeticTarget.cs");

--- a/Faultify.Tests/UnitTests/ArrayTests.cs
+++ b/Faultify.Tests/UnitTests/ArrayTests.cs
@@ -5,6 +5,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test mutations of arrays
+    /// </summary>
     internal class ArrayTests
     {
         private readonly string _folder = Path.Combine("UnitTests", "TestSource", "ArrayTarget.cs");

--- a/Faultify.Tests/UnitTests/AssemblyMutatorTests.cs
+++ b/Faultify.Tests/UnitTests/AssemblyMutatorTests.cs
@@ -11,6 +11,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test the assembly mutator on a dummy assembly.
+    /// </summary>
     public class AssemblyMutatorTests
     {
         private readonly string _folder = Path.Combine("UnitTests", "TestSource", "TestAssemblyTarget.cs");

--- a/Faultify.Tests/UnitTests/BitwiseTests.cs
+++ b/Faultify.Tests/UnitTests/BitwiseTests.cs
@@ -7,6 +7,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test mutations of bitwise/logical operators.
+    /// </summary>
     internal class BitwiseTests
     {
         private readonly string _folder = Path.Combine("UnitTests", "TestSource", "BitwiseTarget.cs");

--- a/Faultify.Tests/UnitTests/BooleanBranchMutatorTests.cs
+++ b/Faultify.Tests/UnitTests/BooleanBranchMutatorTests.cs
@@ -7,6 +7,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test mutations of branching.
+    /// </summary>
     internal class BooleanBranchMutatorTests
     {
         private readonly string _folder = Path.Combine("UnitTests", "TestSource", "BooleanTarget.cs");

--- a/Faultify.Tests/UnitTests/ConstantTests.cs
+++ b/Faultify.Tests/UnitTests/ConstantTests.cs
@@ -5,6 +5,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test mutations of constants.
+    /// </summary>
     internal class ConstantTests
     {
         private const string ConstantBoolTrueName = "CONSTANT_BOOL_TRUE";

--- a/Faultify.Tests/UnitTests/DecompilerTests.cs
+++ b/Faultify.Tests/UnitTests/DecompilerTests.cs
@@ -9,6 +9,9 @@ using ModuleDefinition = MC::Mono.Cecil.ModuleDefinition;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test the decompiler.
+    /// </summary>
     internal class DecompilerTests
     {
         private const string TypeName = "DecompilerTestTarget";

--- a/Faultify.Tests/UnitTests/EqualityTests.cs
+++ b/Faultify.Tests/UnitTests/EqualityTests.cs
@@ -8,6 +8,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test (in)equality and comparison operators.
+    /// </summary>
     internal class EqualityTests
     {
         private readonly string _folder = Path.Combine("UnitTests", "TestSource", "EqualityTarget.cs");

--- a/Faultify.Tests/UnitTests/FileDuplication.cs
+++ b/Faultify.Tests/UnitTests/FileDuplication.cs
@@ -6,6 +6,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test the file duplication system and duplication pool.
+    /// </summary>
     internal class FileDuplicationTests
     {
         [Test]

--- a/Faultify.Tests/UnitTests/LogicalTests.cs
+++ b/Faultify.Tests/UnitTests/LogicalTests.cs
@@ -7,6 +7,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test logical operators.
+    /// </summary>
     internal class LogicalTests
     {
         private readonly string folder = Path.Combine("UnitTests", "TestSource", "LogicalTarget.cs");

--- a/Faultify.Tests/UnitTests/Utils/DllTestHelper.cs
+++ b/Faultify.Tests/UnitTests/Utils/DllTestHelper.cs
@@ -53,7 +53,7 @@ namespace Faultify.Tests.UnitTests.Utils
         /// <summary>
         ///     Compiles CS code to binary code and creates a PDB file for debug symbols.
         /// </summary>
-        ///     See https://stackoverflow.com/questions/50649795/how-to-debug-dll-generated-from-roslyn-compilation
+        /// See https://stackoverflow.com/questions/50649795/how-to-debug-dll-generated-from-roslyn-compilation
         /// <param name="path"></param>
         /// <returns></returns>
         public static byte[] CompileTestBinary(string path)
@@ -97,7 +97,7 @@ namespace Faultify.Tests.UnitTests.Utils
                 Assert.Fail("Could not compile Test Target");
             }
 
-            // TODO: Maybe not the best idea to write this file every single time this runs.
+            // Write debug symbols to file.
             File.WriteAllBytes("test.pdb", symbolStream.ToArray());
 
             return memoryStream.ToArray();

--- a/Faultify.Tests/UnitTests/Utils/DllTestHelper.cs
+++ b/Faultify.Tests/UnitTests/Utils/DllTestHelper.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Text;
 using Faultify.Analyze;
 using Faultify.Analyze.Mutation;
 using Faultify.Analyze.MutationGroups;
@@ -15,6 +16,7 @@ using MC::Mono.Cecil.Rocks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
 using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests.Utils
@@ -49,26 +51,54 @@ namespace Faultify.Tests.UnitTests.Utils
         }
 
         /// <summary>
-        ///     Compiles CS code to binary code (how Dll's supposed to look)
+        ///     Compiles CS code to binary code and creates a PDB file for debug symbols.
         /// </summary>
+        ///     See https://stackoverflow.com/questions/50649795/how-to-debug-dll-generated-from-roslyn-compilation
         /// <param name="path"></param>
         /// <returns></returns>
         public static byte[] CompileTestBinary(string path)
         {
             string source = File.ReadAllText(path);
+            string symbolsName = "test.pdb"; // File for storing debug symbols.
+            var encoding = Encoding.UTF8;
+            byte[] buffer = encoding.GetBytes(source);
+            SourceText sourceText = SourceText.From(buffer, buffer.Length, encoding, canBeEmbedded: true);
 
-            CSharpCompilation compilation = CSharpCompilation.Create("test.dll",
+
+            CSharpCompilation compilation = CSharpCompilation.Create(
+                "test.dll",
                 new[] { CSharpSyntaxTree.ParseText(source) },
                 new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
-                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                    .WithOptimizationLevel(OptimizationLevel.Debug)
+                    .WithPlatform(Platform.AnyCpu)
+                    );
 
-            MemoryStream memoryStream = new MemoryStream();
-            EmitResult emitResult = compilation.Emit(memoryStream);
+            using var memoryStream = new MemoryStream();
+            using var symbolStream = new MemoryStream();
+
+            var emitOptions = new EmitOptions(
+                debugInformationFormat: DebugInformationFormat.PortablePdb,
+                pdbFilePath: symbolsName);
+
+            var embeddedTexts = new List<EmbeddedText>
+            {
+                EmbeddedText.FromSource(path, sourceText),
+            };
+
+            EmitResult emitResult = compilation.Emit(
+                peStream: memoryStream, 
+                pdbStream: symbolStream, 
+                embeddedTexts: embeddedTexts, 
+                options: emitOptions);
 
             if (!emitResult.Success)
             {
                 Assert.Fail("Could not compile Test Target");
             }
+
+            // TODO: Maybe not the best idea to write this file every single time this runs.
+            File.WriteAllBytes("test.pdb", symbolStream.ToArray());
 
             return memoryStream.ToArray();
         }

--- a/Faultify.Tests/UnitTests/VariableLiteralMutatorTests.cs
+++ b/Faultify.Tests/UnitTests/VariableLiteralMutatorTests.cs
@@ -5,6 +5,9 @@ using NUnit.Framework;
 
 namespace Faultify.Tests.UnitTests
 {
+    /// <summary>
+    /// Test flipping booleans.
+    /// </summary>
     internal class VariableLiteralMutatorTests
     {
         private readonly string _folder = Path.Combine("UnitTests", "TestSource", "BooleanLiteralTarget.cs");


### PR DESCRIPTION
No new unit tests were added, as the coverage is already quite high for whatever is testable. We only found two extra classes that could be tested, namely `Utils` and `TestCoverageInjector` , but honestly it seems really unnecessary as they consist of `void`s. Also, if they were actually failing, none of Faultify would be working anyway.  In addition, testing them would require creating a rather complex dummy test project that would cost us time.

We fixed an issue where Faultify would output a blank error message every time a process ran successfully.

For the errors with test timeouts, we think it's best if we set the `NLog.config` to only output *fatal* errors to console. But, we should only do this when we're done doing final checks and are about to submit the final build to the client.

The error data itself is very generic and contains no usable data, therefore it's not possible to filter them out.

